### PR TITLE
Use Namespace class in calicoctl and regex for ip detect

### DIFF
--- a/build_calicoctl/requirements.txt
+++ b/build_calicoctl/requirements.txt
@@ -15,4 +15,4 @@ flask
 gunicorn
 subprocess32
 git+https://github.com/projectcalico/python-etcd.git
-git+https://github.com/projectcalico/libcalico.git@v0.1.2
+git+https://github.com/projectcalico/libcalico.git@v0.1.4

--- a/calico_containers/calico_ctl/node.py
+++ b/calico_containers/calico_ctl/node.py
@@ -202,7 +202,7 @@ def node_start(node_image, log_dir, ip, ip6, as_num, detach, kubernetes,
 
     # Get IP address of host, if none was specified
     if not ip:
-        ips = get_host_ips(exclude=["docker0"])
+        ips = get_host_ips(exclude=["$docker0.*"])
         try:
             ip = ips.pop()
         except IndexError:

--- a/calico_containers/requirements.txt
+++ b/calico_containers/requirements.txt
@@ -6,4 +6,4 @@ gunicorn
 subprocess32
 git+https://github.com/projectcalico/python-etcd.git
 git+https://github.com/projectcalico/calico.git@1.0.0
-git+https://github.com/projectcalico/libcalico.git@v0.1.2
+git+https://github.com/projectcalico/libcalico.git@v0.1.4

--- a/calico_containers/tests/unit/container_test.py
+++ b/calico_containers/tests/unit/container_test.py
@@ -345,6 +345,8 @@ class TestContainer(unittest.TestCase):
         }
         m_endpoint = Mock()
         m_client.get_endpoint.return_value = m_endpoint
+        m_namespace = Mock()
+        m_netns.PidNamespace.return_value = m_namespace
 
         # Set up arguments to pass to method under test
         container_name = 'container1'
@@ -367,9 +369,10 @@ class TestContainer(unittest.TestCase):
         m_client.assign_address.assert_called_once_with(pool_return, ip_addr)
         m_endpoint.ipv4_nets.add.assert_called_once_with(IPNetwork(ip_addr))
         m_client.update_endpoint.assert_called_once_with(m_endpoint)
-        m_netns.add_ip_to_ns_veth.assert_called_once_with(
-            '/proc/Pid_info/ns/net', ip_addr, interface
-        )
+        m_netns.PidNamespace.assert_called_once_with("Pid_info")
+        m_netns.add_ip_to_ns_veth.assert_called_once_with(m_namespace,
+                                                          ip_addr,
+                                                          interface)
 
     @patch('calico_ctl.container.enforce_root', autospec=True)
     @patch('calico_ctl.container.get_pool_or_exit', autospec=True)
@@ -393,6 +396,8 @@ class TestContainer(unittest.TestCase):
         }
         m_endpoint = Mock()
         m_client.get_endpoint.return_value = m_endpoint
+        m_namespace = Mock()
+        m_netns.PidNamespace.return_value = m_namespace
 
         # Set up arguments to pass to method under test
         container_name = 'container1'
@@ -415,9 +420,10 @@ class TestContainer(unittest.TestCase):
         m_client.assign_address.assert_called_once_with(pool_return, ip_addr)
         m_endpoint.ipv6_nets.add.assert_called_once_with(IPNetwork(ip_addr))
         m_client.update_endpoint.assert_called_once_with(m_endpoint)
-        m_netns.add_ip_to_ns_veth.assert_called_once_with(
-            '/proc/Pid_info/ns/net', ip_addr, interface
-        )
+        m_netns.PidNamespace.assert_called_once_with("Pid_info")
+        m_netns.add_ip_to_ns_veth.assert_called_once_with(m_namespace,
+                                                          ip_addr,
+                                                          interface)
 
     @patch('calico_ctl.container.enforce_root', autospec=True)
     @patch('calico_ctl.container.get_pool_or_exit', autospec=True)
@@ -688,6 +694,8 @@ class TestContainer(unittest.TestCase):
         m_endpoint = Mock(spec=Endpoint)
         m_endpoint.ipv4_nets = ipv4_nets
         m_client.get_endpoint.return_value = m_endpoint
+        m_namespace = Mock()
+        m_netns.PidNamespace.return_value = m_namespace
 
         # Set up arguments to pass to method under test
         container_name = 'container1'
@@ -707,11 +715,10 @@ class TestContainer(unittest.TestCase):
             workload_id=666
         )
         m_client.update_endpoint.assert_called_once_with(m_endpoint)
-        m_netns.remove_ip_from_ns_veth.assert_called_once_with(
-            '/proc/Pid_info/ns/net',
-            IPAddress(ip),
-            interface
-        )
+        m_netns.PidNamespace.assert_called_once_with("Pid_info")
+        m_netns.remove_ip_from_ns_veth.assert_called_once_with(m_namespace,
+                                                               IPAddress(ip),
+                                                               interface)
         m_client.unassign_address.assert_called_once_with('pool', ip)
 
     @patch('calico_ctl.container.enforce_root', autospec=True)
@@ -735,6 +742,8 @@ class TestContainer(unittest.TestCase):
         m_endpoint = Mock(spec=Endpoint)
         m_endpoint.ipv6_nets = ipv6_nets
         m_client.get_endpoint.return_value = m_endpoint
+        m_namespace = Mock()
+        m_netns.PidNamespace.return_value = m_namespace
 
         # Set up arguments to pass to method under test
         container_name = 'container1'
@@ -754,11 +763,10 @@ class TestContainer(unittest.TestCase):
             workload_id=666
         )
         m_client.update_endpoint.assert_called_once_with(m_endpoint)
-        m_netns.remove_ip_from_ns_veth.assert_called_once_with(
-            '/proc/Pid_info/ns/net',
-            IPAddress(ip),
-            interface
-        )
+        m_netns.PidNamespace.assert_called_once_with("Pid_info")
+        m_netns.remove_ip_from_ns_veth.assert_called_once_with(m_namespace,
+                                                               IPAddress(ip),
+                                                               interface)
         m_client.unassign_address.assert_called_once_with('pool', ip)
 
     @patch('calico_ctl.container.enforce_root', autospec=True)

--- a/calico_containers/tests/unit/node_test.py
+++ b/calico_containers/tests/unit/node_test.py
@@ -225,7 +225,7 @@ class TestNode(unittest.TestCase):
         m_os_path_exists.assert_called_once_with(log_dir)
         m_os_makedirs.assert_called_once_with(log_dir)
         m_check_system.assert_called_once_with(fix=False, quit_if_error=False)
-        m_get_host_ips.assert_called_once_with(exclude=["docker0"])
+        m_get_host_ips.assert_called_once_with(exclude=["$docker0.*"])
         m_warn_if_unknown_ip.assert_called_once_with(ip_2, ip6)
         m_warn_if_hostname_conflict.assert_called_once_with(ip_2)
         m_install_kube.assert_called_once_with(node.KUBERNETES_PLUGIN_DIR)


### PR DESCRIPTION
Calicoctl container commands now use the Namespace class to coincide with interface changes to namespace functions in libcalico.

Now use a regex for excluding the docker bridge interface when getting the machine's IP in calicoctl node.