### PR TITLE
Don't include cbr0 in IP autodetect

### DIFF
--- a/calico_containers/calico_ctl/node.py
+++ b/calico_containers/calico_ctl/node.py
@@ -202,7 +202,7 @@ def node_start(node_image, log_dir, ip, ip6, as_num, detach, kubernetes,
 
     # Get IP address of host, if none was specified
     if not ip:
-        ips = get_host_ips(exclude=["$docker0.*"])
+        ips = get_host_ips(exclude=["^docker.*", "^cbr.*"])
         try:
             ip = ips.pop()
         except IndexError:

--- a/calico_containers/tests/unit/node_test.py
+++ b/calico_containers/tests/unit/node_test.py
@@ -225,7 +225,7 @@ class TestNode(unittest.TestCase):
         m_os_path_exists.assert_called_once_with(log_dir)
         m_os_makedirs.assert_called_once_with(log_dir)
         m_check_system.assert_called_once_with(fix=False, quit_if_error=False)
-        m_get_host_ips.assert_called_once_with(exclude=["$docker0.*"])
+        m_get_host_ips.assert_called_once_with(exclude=["^docker.*", "^cbr.*"])
         m_warn_if_unknown_ip.assert_called_once_with(ip_2, ip6)
         m_warn_if_hostname_conflict.assert_called_once_with(ip_2)
         m_install_kube.assert_called_once_with(node.KUBERNETES_PLUGIN_DIR)


### PR DESCRIPTION
Fixes issue found [here](https://github.com/projectcalico/libcalico/issues/15)