### PR TITLE
Forces integer notation in templates for AS numbers in the 4-byte range

### DIFF
--- a/node_filesystem/templates/bird.cfg.template
+++ b/node_filesystem/templates/bird.cfg.template
@@ -77,7 +77,7 @@ template bgp bgp_template {
 {{$nums := split $data.ip "."}}{{$id := join $nums "_"}}
 # For peer {{.Key}}
 protocol bgp Global_{{$id}} from bgp_template {
-  neighbor {{$data.ip}} as {{$data.as_num}};
+  neighbor {{$data.ip}} as {{printf "%.0f" $data.as_num}};
 }
 {{end}}
 {{else}}# No global peers configured.{{end}}
@@ -90,7 +90,7 @@ protocol bgp Global_{{$id}} from bgp_template {
 {{$nums := split $data.ip "."}}{{$id := join $nums "_"}}
 # For peer {{.Key}}
 protocol bgp Node_{{$id}} from bgp_template {
-  neighbor {{$data.ip}} as {{$data.as_num}};
+  neighbor {{$data.ip}} as {{printf "%.0f" $data.as_num}};
 }
 {{end}}
 {{else}}# No node-specific peers configured.{{end}}

--- a/node_filesystem/templates/bird6.cfg.template
+++ b/node_filesystem/templates/bird6.cfg.template
@@ -79,7 +79,7 @@ template bgp bgp_template {
 {{$nums := split $data.ip "."}}{{$id := join $nums "_"}}
 # For peer {{.Key}}
 protocol bgp Global_{{$id}} from bgp_template {
-  neighbor {{$data.ip}} as {{$data.as_num}};
+  neighbor {{$data.ip}} as {{printf "%.0f" $data.as_num}};
 }
 {{end}}
 {{else}}# No global peers configured.{{end}}
@@ -92,7 +92,7 @@ protocol bgp Global_{{$id}} from bgp_template {
 {{$nums := split $data.ip "."}}{{$id := join $nums "_"}}
 # For peer {{.Key}}
 protocol bgp Node_{{$id}} from bgp_template {
-  neighbor {{$data.ip}} as {{$data.as_num}};
+  neighbor {{$data.ip}} as {{printf "%.0f" $data.as_num}};
 }
 {{end}}
 {{else}}# No node-specific peers configured.{{end}}


### PR DESCRIPTION
Prior to this, 4-byte integers would appear in scientific notation