### PR TITLE
Install a more recent version of pip/setuptools.

### DIFF
--- a/image/base.sh
+++ b/image/base.sh
@@ -19,14 +19,21 @@ grep -Fxvf  /tmp/base.txt <(dpkg -l | grep ^ii | sed 's_  _\t_g' | cut \
 
 # Install packages that should not be removed in the cleanup processing.
 # - packages required by felix
-# - pip (which includes various setuptools package discovery).
 #apt-get install -qy \
 $minimal_apt_get_install \
         iptables \
         ipset \
         conntrack \
         net-tools \
-        python-pip=1.5.4-1
+        ca-certificates \
+        python
+
+# Get a recent version of pip and setuptools.  The Ubuntu version of setuptools
+# is too old to understand python-etcd's version number (0.4.1+calico.1).
+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+python ./get-pip.py
+rm get-pip.py
+pip install -U setuptools
 
 # Copy patched BIRD daemon with tunnel support.
 curl -L https://github.com/projectcalico/calico-bird/releases/download/v0.1.0/bird -o /usr/sbin/bird && \


### PR DESCRIPTION
python-setuptools is old enough to have a bug that balks on python-etcd's version number (0.4.1+calico.1).  This works around by getting an up-to-date pip and setuptools.

Had to install ca-certificates manually, they were being pulled in as an indirect dependency and they're required to run curl.