### PR TITLE
Lockdown versions of projectcalico repos

### DIFF
--- a/build_calicoctl/requirements.txt
+++ b/build_calicoctl/requirements.txt
@@ -14,5 +14,5 @@ netaddr==0.7.15
 flask
 gunicorn
 subprocess32
-git+https://github.com/projectcalico/python-etcd.git
-git+https://github.com/projectcalico/libcalico.git
+git+https://github.com/projectcalico/python-etcd.git@0.4.1+calico.1
+git+https://github.com/projectcalico/libcalico.git@v0.3.0

--- a/calico_containers/requirements.txt
+++ b/calico_containers/requirements.txt
@@ -4,7 +4,7 @@ six==1.9.0
 flask
 gunicorn
 subprocess32
-git+https://github.com/projectcalico/python-etcd.git
+git+https://github.com/projectcalico/python-etcd.git@0.4.1+calico.1
 git+https://github.com/projectcalico/python-posix-spawn.git@smc-debianize#egg=posix-spawn
-git+https://github.com/projectcalico/calico.git
-git+https://github.com/projectcalico/libcalico.git
+git+https://github.com/projectcalico/calico.git@1.1.0
+git+https://github.com/projectcalico/libcalico.git@v0.3.0


### PR DESCRIPTION
Update build to specify most recent upstream releases.
[python-etcd@0.4.1-calico.1](https://github.com/projectcalico/python-etcd/releases/tag/0.4.1%2Bcalico.1)
[libcalico@v0.3.0](https://github.com/projectcalico/libcalico/releases/tag/v0.3.0)
[calico@1.1.0](https://github.com/projectcalico/calico/releases/tag/1.1.0)