### PR TITLE
Create ip6tables command object within try/except

### DIFF
--- a/calico_containers/calico_ctl/checksystem.py
+++ b/calico_containers/calico_ctl/checksystem.py
@@ -101,9 +101,9 @@ def _check_kernel_modules(fix):
     :return: True if kernel modules are ok.
     """
     modprobe = sh.Command._create('modprobe')
-    ip6tables = sh.Command._create('ip6tables')
     system_ok = True
     try:
+        ip6tables = sh.Command._create('ip6tables')
         ip6tables("-L")
     except:
         if fix:


### PR DESCRIPTION
+ Fixes projectcalico/calico-docker#531
+ Command obj creation will cause check_system to fail silently without hitting our loud exception handlers.