### PR TITLE
Deprecate `--fix` flag of `calicoctl checksystem`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,6 @@ calico_containers/calico-node.tar: caliconode.created
 	docker save --output calico_containers/calico-node.tar calico/node
 
 st: binary calico_containers/busybox.tar calico_containers/routereflector.tar calico_containers/calico-node.tar run-etcd
-	sudo dist/calicoctl checksystem
 	nosetests $(ST_TO_RUN) -sv --nologcapture --with-timer
 
 fast-st: calico_containers/busybox.tar calico_containers/routereflector.tar calico_containers/calico-node.tar run-etcd

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ calico_containers/calico-node.tar: caliconode.created
 	docker save --output calico_containers/calico-node.tar calico/node
 
 st: binary calico_containers/busybox.tar calico_containers/routereflector.tar calico_containers/calico-node.tar run-etcd
-	sudo dist/calicoctl checksystem --fix
+	sudo dist/calicoctl checksystem
 	nosetests $(ST_TO_RUN) -sv --nologcapture --with-timer
 
 fast-st: calico_containers/busybox.tar calico_containers/routereflector.tar calico_containers/calico-node.tar run-etcd

--- a/calico_containers/calico_ctl/checksystem.py
+++ b/calico_containers/calico_ctl/checksystem.py
@@ -56,6 +56,7 @@ def check_system(quit_if_error=False, libnetwork=False):
 
     :param quit_if_error: if True, quit with error code 1 if any issues are
     detected.
+    :param libnetwork: If True, check for Docker version >= v1.21 to support libnetwork
     :return: True if all system dependencies are in the proper state, False if
     they are not. This function will sys.exit(1) instead of returning false if
     quit_if_error == True
@@ -118,7 +119,7 @@ def _check_kernel_modules():
 def _check_docker_version(libnetwork=False):
     """
     Check the Docker version is supported.
-
+    :param libnetwork: If True, check for Docker version >= v1.21 to support libnetwork
     :return: True if Docker version is OK.
     """
     system_ok = True

--- a/calico_containers/calico_ctl/node.py
+++ b/calico_containers/calico_ctl/node.py
@@ -214,7 +214,7 @@ def node_start(node_image, log_dir, ip, ip6, as_num, detach, kubernetes, rkt,
     :return:  None.
     """
     # Print warnings for any known system issues before continuing
-    check_system(fix=False, quit_if_error=False, libnetwork=libnetwork_image)
+    check_system(quit_if_error=False, libnetwork=libnetwork_image)
 
     # We will always want to setup IP forwarding
     _setup_ip_forwarding()

--- a/calico_containers/calico_ctl/utils.py
+++ b/calico_containers/calico_ctl/utils.py
@@ -24,6 +24,7 @@ DOCKER_VERSION = "1.16"
 DOCKER_LIBNETWORK_VERSION = "1.21"
 DOCKER_ORCHESTRATOR_ID = "docker"
 NAMESPACE_ORCHESTRATOR_ID = "namespace"
+REQUIRED_MODULES = ["xt_set", "ip6_tables"]
 hostname = socket.gethostname()
 
 

--- a/calico_containers/tests/st/test_checksystem.py
+++ b/calico_containers/tests/st/test_checksystem.py
@@ -20,8 +20,6 @@ Test calicoctl checksystem
 
 It's worth doing a simple return code check. Anything more is going to be
 difficult given the environmental requirements.
-
-The --fix command is already executed as part of the tests (in the Makefile)
 """
 
 

--- a/calico_containers/tests/unit/checksystem_test.py
+++ b/calico_containers/tests/unit/checksystem_test.py
@@ -1,131 +1,131 @@
-# Copyright 2015 Metaswitch Networks
+# # Copyright 2015 Metaswitch Networks
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #     http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# import unittest
+# from mock import patch, Mock
+# from calico_ctl.checksystem import _check_modules
+# from sh import Command, ErrorReturnCode
+# from nose_parameterized import parameterized
+# from calico_ctl.checksystem import check_system
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-import unittest
-from mock import patch, Mock
-from calico_ctl.checksystem import _check_kernel_modules
-from sh import Command, ErrorReturnCode
-from nose_parameterized import parameterized
-from calico_ctl.checksystem import check_system
-
-
-class TestCheckSystem(unittest.TestCase):
-
-    @patch("calico_ctl.checksystem.sh.Command", autospec=True)
-    def test_check_mod_xt_set(self, m_command):
-
-        # Mock out sh.Command._create
-        m_modprobe = Mock(Command)
-        m_ip6tables = Mock(Command)
-
-        def _create(cmd):
-            if cmd == "modprobe":
-                return m_modprobe
-            elif cmd == "ip6tables":
-                return m_ip6tables
-            else:
-                raise ValueError()
-        m_command._create = _create
-
-        def m_module_loaded(module):
-            return False
-
-        with patch("calico_ctl.checksystem.module_loaded", m_module_loaded):
-            result = _check_kernel_modules()
-
-            self.assertFalse(result)
-            self.assertFalse(m_modprobe.called)
-            m_ip6tables.assert_called_once_with("-L")
-
-    @patch('calico_ctl.checksystem.enforce_root', autospec=True)
-    @patch('calico_ctl.checksystem._check_kernel_modules', autospec=True, return_value=True)
-    @patch('calico_ctl.checksystem._check_docker_version', autospec=True, return_value=True)
-    def test_check_system(self, m_check_docker_version,
-                          m_check_kernel_modules, m_enforce_root):
-        """
-        Test for check_system when all checks pass
-
-        Assert that the function returns True
-        """
-        # Call method under test
-        test_return = check_system(quit_if_error=True)
-
-        # Assert
-        m_enforce_root.assert_called_once_with()
-        m_check_kernel_modules.assert_called_once_with()
-        m_check_docker_version.assert_called_once_with(False)
-        self.assertTrue(test_return)
-
-    @parameterized.expand([
-        (True, False),
-        (False, True),
-    ])
-    def test_check_system_bad_state_do_not_quit(
-            self, kernel_status, docker_version_status):
-        """
-        Test for check_system when one of the system checks fails
-
-        This test does not quit if there is an error -
-        Assert that the function returns False
-
-        :param kernel_status: return_value for _check_kernel_modules
-        :param docker_version_status: return_value for _check_docker_version
-        """
-        with patch('calico_ctl.checksystem.enforce_root', autospec=True) \
-                     as m_enforce_root, \
-             patch('calico_ctl.checksystem._check_kernel_modules', autospec=True) \
-                     as m_check_kernel_modules, \
-             patch('calico_ctl.checksystem._check_docker_version', autospec=True) \
-                        as m_check_docker_version:
-            # Set up mock objects
-            m_check_kernel_modules.return_value = kernel_status
-            m_check_docker_version.return_value = docker_version_status
-
-            # Call method under test without exiting if error detected
-            test_return = check_system(quit_if_error=False)
-
-            # Assert
-            m_enforce_root.assert_called_once_with()
-            self.assertFalse(test_return)
-
-    @parameterized.expand([
-        (True, False),
-        (False, True),
-    ])
-    def test_check_system_bad_state_quit(
-            self, kernel_status, docker_version_status):
-        """
-        Test for check_system when one of the system checks fails
-
-        This test exits if there is a detected error -
-        Assert that the system exits
-
-        :param kernel_status: return_value for _check_kernel_modules patch
-        :param docker_version_status: return_value for _check_docker_version patch
-        """
-        with patch('calico_ctl.checksystem.enforce_root', autospec=True) \
-                     as m_enforce_root, \
-             patch('calico_ctl.checksystem._check_kernel_modules', autospec=True) \
-                     as m_check_kernel_modules, \
-             patch('calico_ctl.checksystem._check_docker_version', autospec=True) \
-                     as m_check_docker_version:
-            # Set up mock objects
-            m_check_kernel_modules.return_value = kernel_status
-            m_check_docker_version.return_value = docker_version_status
-
-            # Call method under test expecting a SystemExit when fail detected
-            self.assertRaises(SystemExit, check_system, quit_if_error=True)
-
-            # Assert
-            m_enforce_root.assert_called_once_with()
+# class TestCheckSystem(unittest.TestCase):
+#
+#     @patch("calico_ctl.checksystem.sh.Command", autospec=True)
+#     def test_check_mod_xt_set(self, m_command):
+#
+#         # Mock out sh.Command._create
+#         m_modprobe = Mock(Command)
+#         m_ip6tables = Mock(Command)
+#
+#         def _create(cmd):
+#             if cmd == "modprobe":
+#                 return m_modprobe
+#             elif cmd == "ip6tables":
+#                 return m_ip6tables
+#             else:
+#                 raise ValueError()
+#         m_command._create = _create
+#
+#         def m_module_loaded(module):
+#             return False
+#
+#         with patch("calico_ctl.checksystem.modules_available", m_module_loaded):
+#             result = _check_modules()
+#
+#             self.assertFalse(result)
+#             self.assertFalse(m_modprobe.called)
+#             m_ip6tables.assert_called_once_with("-L")
+#
+#     @patch('calico_ctl.checksystem.enforce_root', autospec=True)
+#     @patch('calico_ctl.checksystem._check_modules', autospec=True, return_value=True)
+#     @patch('calico_ctl.checksystem._check_docker_version', autospec=True, return_value=True)
+#     def test_check_system(self, m_check_docker_version,
+#                           m_check_kernel_modules, m_enforce_root):
+#         """
+#         Test for check_system when all checks pass
+#
+#         Assert that the function returns True
+#         """
+#         # Call method under test
+#         test_return = check_system(quit_if_error=True)
+#
+#         # Assert
+#         m_enforce_root.assert_called_once_with()
+#         m_check_kernel_modules.assert_called_once_with()
+#         m_check_docker_version.assert_called_once_with(False)
+#         self.assertTrue(test_return)
+#
+#     @parameterized.expand([
+#         (True, False),
+#         (False, True),
+#     ])
+#     def test_check_system_bad_state_do_not_quit(
+#             self, kernel_status, docker_version_status):
+#         """
+#         Test for check_system when one of the system checks fails
+#
+#         This test does not quit if there is an error -
+#         Assert that the function returns False
+#
+#         :param kernel_status: return_value for _check_modules
+#         :param docker_version_status: return_value for _check_docker_version
+#         """
+#         with patch('calico_ctl.checksystem.enforce_root', autospec=True) \
+#                      as m_enforce_root, \
+#              patch('calico_ctl.checksystem._check_modules', autospec=True) \
+#                      as m_check_kernel_modules, \
+#              patch('calico_ctl.checksystem._check_docker_version', autospec=True) \
+#                         as m_check_docker_version:
+#             # Set up mock objects
+#             m_check_kernel_modules.return_value = kernel_status
+#             m_check_docker_version.return_value = docker_version_status
+#
+#             # Call method under test without exiting if error detected
+#             test_return = check_system(quit_if_error=False)
+#
+#             # Assert
+#             m_enforce_root.assert_called_once_with()
+#             self.assertFalse(test_return)
+#
+#     @parameterized.expand([
+#         (True, False),
+#         (False, True),
+#     ])
+#     def test_check_system_bad_state_quit(
+#             self, kernel_status, docker_version_status):
+#         """
+#         Test for check_system when one of the system checks fails
+#
+#         This test exits if there is a detected error -
+#         Assert that the system exits
+#
+#         :param kernel_status: return_value for _check_modules patch
+#         :param docker_version_status: return_value for _check_docker_version patch
+#         """
+#         with patch('calico_ctl.checksystem.enforce_root', autospec=True) \
+#                      as m_enforce_root, \
+#              patch('calico_ctl.checksystem._check_modules', autospec=True) \
+#                      as m_check_kernel_modules, \
+#              patch('calico_ctl.checksystem._check_docker_version', autospec=True) \
+#                      as m_check_docker_version:
+#             # Set up mock objects
+#             m_check_kernel_modules.return_value = kernel_status
+#             m_check_docker_version.return_value = docker_version_status
+#
+#             # Call method under test expecting a SystemExit when fail detected
+#             self.assertRaises(SystemExit, check_system, quit_if_error=True)
+#
+#             # Assert
+#             m_enforce_root.assert_called_once_with()

--- a/calico_containers/tests/unit/checksystem_test.py
+++ b/calico_containers/tests/unit/checksystem_test.py
@@ -1,131 +1,165 @@
-# # Copyright 2015 Metaswitch Networks
-# #
-# # Licensed under the Apache License, Version 2.0 (the "License");
-# # you may not use this file except in compliance with the License.
-# # You may obtain a copy of the License at
-# #
-# #     http://www.apache.org/licenses/LICENSE-2.0
-# #
-# # Unless required by applicable law or agreed to in writing, software
-# # distributed under the License is distributed on an "AS IS" BASIS,
-# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# # See the License for the specific language governing permissions and
-# # limitations under the License.
+# Copyright 2015 Metaswitch Networks
 #
-# import unittest
-# from mock import patch, Mock
-# from calico_ctl.checksystem import _check_modules
-# from sh import Command, ErrorReturnCode
-# from nose_parameterized import parameterized
-# from calico_ctl.checksystem import check_system
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# class TestCheckSystem(unittest.TestCase):
-#
-#     @patch("calico_ctl.checksystem.sh.Command", autospec=True)
-#     def test_check_mod_xt_set(self, m_command):
-#
-#         # Mock out sh.Command._create
-#         m_modprobe = Mock(Command)
-#         m_ip6tables = Mock(Command)
-#
-#         def _create(cmd):
-#             if cmd == "modprobe":
-#                 return m_modprobe
-#             elif cmd == "ip6tables":
-#                 return m_ip6tables
-#             else:
-#                 raise ValueError()
-#         m_command._create = _create
-#
-#         def m_module_loaded(module):
-#             return False
-#
-#         with patch("calico_ctl.checksystem.modules_available", m_module_loaded):
-#             result = _check_modules()
-#
-#             self.assertFalse(result)
-#             self.assertFalse(m_modprobe.called)
-#             m_ip6tables.assert_called_once_with("-L")
-#
-#     @patch('calico_ctl.checksystem.enforce_root', autospec=True)
-#     @patch('calico_ctl.checksystem._check_modules', autospec=True, return_value=True)
-#     @patch('calico_ctl.checksystem._check_docker_version', autospec=True, return_value=True)
-#     def test_check_system(self, m_check_docker_version,
-#                           m_check_kernel_modules, m_enforce_root):
-#         """
-#         Test for check_system when all checks pass
-#
-#         Assert that the function returns True
-#         """
-#         # Call method under test
-#         test_return = check_system(quit_if_error=True)
-#
-#         # Assert
-#         m_enforce_root.assert_called_once_with()
-#         m_check_kernel_modules.assert_called_once_with()
-#         m_check_docker_version.assert_called_once_with(False)
-#         self.assertTrue(test_return)
-#
-#     @parameterized.expand([
-#         (True, False),
-#         (False, True),
-#     ])
-#     def test_check_system_bad_state_do_not_quit(
-#             self, kernel_status, docker_version_status):
-#         """
-#         Test for check_system when one of the system checks fails
-#
-#         This test does not quit if there is an error -
-#         Assert that the function returns False
-#
-#         :param kernel_status: return_value for _check_modules
-#         :param docker_version_status: return_value for _check_docker_version
-#         """
-#         with patch('calico_ctl.checksystem.enforce_root', autospec=True) \
-#                      as m_enforce_root, \
-#              patch('calico_ctl.checksystem._check_modules', autospec=True) \
-#                      as m_check_kernel_modules, \
-#              patch('calico_ctl.checksystem._check_docker_version', autospec=True) \
-#                         as m_check_docker_version:
-#             # Set up mock objects
-#             m_check_kernel_modules.return_value = kernel_status
-#             m_check_docker_version.return_value = docker_version_status
-#
-#             # Call method under test without exiting if error detected
-#             test_return = check_system(quit_if_error=False)
-#
-#             # Assert
-#             m_enforce_root.assert_called_once_with()
-#             self.assertFalse(test_return)
-#
-#     @parameterized.expand([
-#         (True, False),
-#         (False, True),
-#     ])
-#     def test_check_system_bad_state_quit(
-#             self, kernel_status, docker_version_status):
-#         """
-#         Test for check_system when one of the system checks fails
-#
-#         This test exits if there is a detected error -
-#         Assert that the system exits
-#
-#         :param kernel_status: return_value for _check_modules patch
-#         :param docker_version_status: return_value for _check_docker_version patch
-#         """
-#         with patch('calico_ctl.checksystem.enforce_root', autospec=True) \
-#                      as m_enforce_root, \
-#              patch('calico_ctl.checksystem._check_modules', autospec=True) \
-#                      as m_check_kernel_modules, \
-#              patch('calico_ctl.checksystem._check_docker_version', autospec=True) \
-#                      as m_check_docker_version:
-#             # Set up mock objects
-#             m_check_kernel_modules.return_value = kernel_status
-#             m_check_docker_version.return_value = docker_version_status
-#
-#             # Call method under test expecting a SystemExit when fail detected
-#             self.assertRaises(SystemExit, check_system, quit_if_error=True)
-#
-#             # Assert
-#             m_enforce_root.assert_called_once_with()
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+from mock import patch, Mock, call
+from sh import Command, ErrorReturnCode
+from nose_parameterized import parameterized
+from calico_ctl.checksystem import check_system, _check_modules
+
+
+class TestCheckSystem(unittest.TestCase):
+
+    @patch('calico_ctl.checksystem.enforce_root', autospec=True)
+    @patch('calico_ctl.checksystem._check_modules', autospec=True, return_value=True)
+    @patch('calico_ctl.checksystem._check_docker_version', autospec=True, return_value=True)
+    def test_check_system(self, m_check_docker_version,
+                          m_check_kernel_modules, m_enforce_root):
+        """
+        Test for check_system when all checks pass
+
+        Assert that the function returns True
+        """
+        # Call method under test
+        test_return = check_system(quit_if_error=True)
+
+        # Assert
+        m_enforce_root.assert_called_once_with()
+        m_check_kernel_modules.assert_called_once_with()
+        m_check_docker_version.assert_called_once_with(False)
+        self.assertTrue(test_return)
+
+    @parameterized.expand([
+        (True, False),
+        (False, True),
+    ])
+    @patch('calico_ctl.checksystem.enforce_root', autospec=True)
+    @patch('calico_ctl.checksystem._check_modules', autospec=True)
+    @patch('calico_ctl.checksystem._check_docker_version', autospec=True)
+    def test_check_system_bad_state_do_not_quit(
+            self, kernel_status, docker_version_status,
+            m_check_docker_version, m_check_kernel_modules, m_enforce_root):
+        """
+        Test for check_system when one of the system checks fails
+
+        This test does not quit if there is an error -
+        Assert that the function returns False
+
+        :param kernel_status: return_value for _check_modules
+        :param docker_version_status: return_value for _check_docker_version
+        """
+        # Set up mock objects
+        m_check_kernel_modules.return_value = kernel_status
+        m_check_docker_version.return_value = docker_version_status
+
+        # Call method under test without exiting if error detected
+        test_return = check_system(quit_if_error=False)
+
+        # Assert
+        self.assertFalse(test_return)
+
+    @parameterized.expand([
+        (True, False),
+        (False, True),
+    ])
+    @patch('calico_ctl.checksystem.enforce_root', autospec=True)
+    @patch('calico_ctl.checksystem._check_modules', autospec=True)
+    @patch('calico_ctl.checksystem._check_docker_version', autospec=True)
+    def test_check_system_bad_state_quit(
+            self, kernel_status, docker_version_status,
+            m_check_docker_version, m_check_kernel_modules, m_enforce_root):
+        """
+        Test for check_system when one of the system checks fails
+
+        This test exits if there is a detected error -
+        Assert that the system exits
+
+        :param kernel_status: return_value for _check_modules patch
+        :param docker_version_status: return_value for _check_docker_version patch
+        """
+        # Set up mock objects
+        m_check_kernel_modules.return_value = kernel_status
+        m_check_docker_version.return_value = docker_version_status
+
+        # Call method under test expecting a SystemExit when fail detected
+        self.assertRaises(SystemExit, check_system, quit_if_error=True)
+
+    # Numbered modules exist within the mocked files and should be valid
+    # check_modules should return false if searching for invalid module
+    @parameterized.expand([
+        (["mod_one", "mod_four"], True),
+        (["mod_four", "mod_five"], True),
+        (["mod_invalid"], False),
+        (["mod_one", "mod_invalid"], False),
+        (["mod_four", "mod_invalid"], False),
+    ])
+    @patch('__builtin__.open', autospec=True)
+    @patch('sys.stderr', autospec=True)
+    @patch('calico_ctl.checksystem.check_output', autospec=True, return_value="version")
+    def test_check_modules_double_open(self, requirements, expected_return,
+                                       m_get_version, m_stderr, m_open):
+        """Test _check_module for different requirements (opening 2 files)
+        Use parameterized requirements to test a variety of states in which
+        modules may or not be found. Check the number of calls to open().
+        Numbered modules exist within the mocked files and should be valid.
+        check_modules should return false if searching for the invalid module.
+        """
+        m_file = Mock()
+        m_file.readlines.side_effect = [["/mod_one.ko", "/mod_two.ko", "/mod_three.ko"], # Mocked Available modules
+                                        ["/mod_four.ko", "/mod_five.ko"],                # Mocked Builtin modules
+                                       ]
+        m_open.return_value = m_file
+
+        with patch('calico_ctl.checksystem.REQUIRED_MODULES', requirements):
+            return_val = _check_modules()
+
+        self.assertEquals(return_val, expected_return)
+        m_open.assert_has_calls([call("/lib/modules/version/modules.dep"),
+                                 call().readlines(),
+                                 call("/lib/modules/version/modules.builtin"),
+                                 call().readlines(),
+                                ])
+
+    @parameterized.expand([
+        (["mod_one", "mod_two"], True),
+        (["mod_three"], True),
+    ])
+    @patch('__builtin__.open', autospec=True)
+    @patch('sys.stderr', autospec=True)
+    @patch('calico_ctl.checksystem.check_output', autospec=True, return_value="version")
+    def test_check_modules_single_open(self, requirements, expected_return,
+                                       m_get_version, m_stderr, m_open):
+        """Test _check_module for different requirements (opening 1 file)
+        Use parameterized requirements to test a variety of states in which
+        modules may or not be found. Check the number of calls to open().
+        Numbered modules exist within the mocked file and should be valid.
+        """
+        m_file = Mock()
+        m_file.readlines.return_value = ["/mod_one.ko", "/mod_two.ko", "/mod_three.ko"] # Mocked Available modules
+
+        m_open.return_value = m_file
+
+        with patch('calico_ctl.checksystem.REQUIRED_MODULES', requirements):
+            return_val = _check_modules()
+
+        m_open.assert_called_once_with("/lib/modules/version/modules.dep")
+        self.assertEquals(return_val, expected_return)
+
+    @patch('sys.stderr', autospec=True)
+    @patch('calico_ctl.checksystem.check_output', autospec=True, side_effect=OSError)
+    def test_check_modules_version_error(self, m_get_version, m_stderr):
+        """Test _check_module for error in grabbing version
+        check_system should fail if version cannot be found with `uname`
+        """
+        return_val = _check_modules()
+        self.assertEquals(return_val, False)

--- a/calico_containers/tests/unit/checksystem_test.py
+++ b/calico_containers/tests/unit/checksystem_test.py
@@ -42,34 +42,10 @@ class TestCheckSystem(unittest.TestCase):
             return False
 
         with patch("calico_ctl.checksystem.module_loaded", m_module_loaded):
-            result = _check_kernel_modules(False)
+            result = _check_kernel_modules()
 
-            # Fix = false means system is not OK.
             self.assertFalse(result)
             self.assertFalse(m_modprobe.called)
-            m_ip6tables.assert_called_once_with("-L")
-
-            # Reset mocks
-            m_modprobe.reset_mock()
-            m_ip6tables.reset_mock()
-
-            result = _check_kernel_modules(True)
-
-            # Fix = true should attempt to fix with modprobe.
-            self.assertTrue(result)
-            m_modprobe.assert_called_once_with("xt_set")
-            m_ip6tables.assert_called_once_with("-L")
-
-            # Reset mocks
-            m_modprobe.reset_mock()
-            m_ip6tables.reset_mock()
-
-            # Fix = true, but modprobe fails.
-            m_modprobe.side_effect = ErrorReturnCode("modprobe xt_set", "", "")
-            result = _check_kernel_modules(True)
-
-            self.assertFalse(result)
-            m_modprobe.assert_called_once_with("xt_set")
             m_ip6tables.assert_called_once_with("-L")
 
     @patch('calico_ctl.checksystem.enforce_root', autospec=True)
@@ -83,11 +59,11 @@ class TestCheckSystem(unittest.TestCase):
         Assert that the function returns True
         """
         # Call method under test
-        test_return = check_system(fix=False, quit_if_error=True)
+        test_return = check_system(quit_if_error=True)
 
         # Assert
         m_enforce_root.assert_called_once_with()
-        m_check_kernel_modules.assert_called_once_with(False)
+        m_check_kernel_modules.assert_called_once_with()
         m_check_docker_version.assert_called_once_with(False)
         self.assertTrue(test_return)
 
@@ -117,7 +93,7 @@ class TestCheckSystem(unittest.TestCase):
             m_check_docker_version.return_value = docker_version_status
 
             # Call method under test without exiting if error detected
-            test_return = check_system(fix=False, quit_if_error=False)
+            test_return = check_system(quit_if_error=False)
 
             # Assert
             m_enforce_root.assert_called_once_with()
@@ -149,7 +125,7 @@ class TestCheckSystem(unittest.TestCase):
             m_check_docker_version.return_value = docker_version_status
 
             # Call method under test expecting a SystemExit when fail detected
-            self.assertRaises(SystemExit, check_system, fix=False, quit_if_error=True)
+            self.assertRaises(SystemExit, check_system, quit_if_error=True)
 
             # Assert
             m_enforce_root.assert_called_once_with()

--- a/calico_containers/tests/unit/node_test.py
+++ b/calico_containers/tests/unit/node_test.py
@@ -220,7 +220,7 @@ class TestNode(unittest.TestCase):
         # Assert
         m_os_path_exists.assert_called_once_with(log_dir)
         m_os_makedirs.assert_called_once_with(log_dir)
-        m_check_system.assert_called_once_with(fix=False, quit_if_error=False, libnetwork=libnetwork)
+        m_check_system.assert_called_once_with(quit_if_error=False, libnetwork=libnetwork)
         m_setup_ip.assert_called_once_with()
         m_get_host_ips.assert_called_once_with(exclude=["^docker.*", "^cbr.*"])
         m_warn_if_unknown_ip.assert_called_once_with(ip_2, ip6)

--- a/docs/getting-started/default-networking/EnvironmentSetup.md
+++ b/docs/getting-started/default-networking/EnvironmentSetup.md
@@ -31,7 +31,7 @@ for using the default Docker networking.
 
 The two Linux servers require a recent version of Linux with a few network 
 network related kernel modules to be loaded. The easiest way to ensure this and
-that the servers meet the requirements is to run `calicoctl checksystem --fix`
+that the servers meet the requirements is to run `calicoctl checksystem`
 
 The servers also need:
 - Docker to be running - since the Calico agent is packaged as a Docker 

--- a/docs/getting-started/default-networking/cloud-config/user-data-first
+++ b/docs/getting-started/default-networking/cloud-config/user-data-first
@@ -47,4 +47,3 @@ write_files:
     #!/usr/bin/bash -e
     wget -O /opt/bin/calicoctl https://github.com/projectcalico/calico-docker/releases/download/v0.8.0/calicoctl
     chmod +x /opt/bin/calicoctl
-    /opt/bin/calicoctl checksystem --fix

--- a/docs/getting-started/default-networking/cloud-config/user-data-others
+++ b/docs/getting-started/default-networking/cloud-config/user-data-others
@@ -42,4 +42,3 @@ write_files:
     #!/usr/bin/bash -e
     wget -O /opt/bin/calicoctl https://github.com/projectcalico/calico-docker/releases/download/v0.8.0/calicoctl
     chmod +x /opt/bin/calicoctl
-    /opt/bin/calicoctl checksystem --fix

--- a/docs/getting-started/default-networking/vagrant-ubuntu/Vagrantfile
+++ b/docs/getting-started/default-networking/vagrant-ubuntu/Vagrantfile
@@ -46,9 +46,6 @@ Vagrant.configure(2) do |config|
 
       host.vm.provision :shell, inline: "chmod +x /usr/local/bin/calicoctl"
 
-      # Ensure that the iptables kernel modules are loaded etc...
-      host.vm.provision :shell, inline: "sudo calicoctl checksystem --fix"
-
       # Calico uses etcd for clustering. Install it on the first host only.
       if i == 1
         host.vm.provision :docker do |d|

--- a/docs/getting-started/libnetwork/EnvironmentSetup.md
+++ b/docs/getting-started/libnetwork/EnvironmentSetup.md
@@ -31,7 +31,7 @@ for using libnetwork.
 
 The two Linux servers require a recent version of Linux with a few network 
 network related kernel modules to be loaded. The easiest way to ensure this and
-that the servers meet the requirements is to run `calicoctl checksystem --fix`
+that the servers meet the requirements is to run `calicoctl checksystem`
 
 The servers also need:
 - A specific Docker release to be running - since the Calico agent is packaged

--- a/docs/getting-started/libnetwork/cloud-config/user-data-first
+++ b/docs/getting-started/libnetwork/cloud-config/user-data-first
@@ -54,7 +54,6 @@ coreos:
       LimitNOFILE=1048576
       LimitNPROC=1048576
       ExecStart=/opt/bin/docker --cluster-store=etcd://$private_ipv4:4001 --daemon --host=fd:// $DOCKER_OPTS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
-      ExecStartPost=/opt/bin/calicoctl checksystem --fix
       RestartSec=10
       Restart=always
 

--- a/docs/getting-started/libnetwork/cloud-config/user-data-others
+++ b/docs/getting-started/libnetwork/cloud-config/user-data-others
@@ -49,7 +49,6 @@ coreos:
       LimitNOFILE=1048576
       LimitNPROC=1048576
       ExecStart=/opt/bin/docker --cluster-store=etcd://172.17.8.101:4001 --daemon --host=fd:// $DOCKER_OPTS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
-      ExecStartPost=/opt/bin/calicoctl checksystem --fix
       RestartSec=10
       Restart=always
 

--- a/docs/getting-started/libnetwork/vagrant-ubuntu/Vagrantfile
+++ b/docs/getting-started/libnetwork/vagrant-ubuntu/Vagrantfile
@@ -70,9 +70,6 @@ Vagrant.configure(2) do |config|
 
       host.vm.provision :shell, inline: "chmod +x /usr/local/bin/calicoctl"
 
-      # Ensure that the iptables kernel modules are loaded etc...
-      host.vm.provision :shell, inline: "sudo calicoctl checksystem --fix"
-
       # Ensure the vagrant and root users get the ETCD_AUTHORITY environment.
       host.vm.provision :shell, inline: %Q|echo 'export ETCD_AUTHORITY="#{primary_ip}:4001"' >> /home/vagrant/.profile|
       host.vm.provision :shell, inline: %Q|sudo sh -c 'echo "Defaults env_keep +=\"ETCD_AUTHORITY\"" >>/etc/sudoers'|

--- a/docs/getting-started/powerstrip/CalicoSwarm.md
+++ b/docs/getting-started/powerstrip/CalicoSwarm.md
@@ -66,7 +66,7 @@ export ETCD_AUTHORITY=$MANAGER_IP:4001
 export DOCKER_HOST=localhost:2377
 
 # Check that all required dependencies are installed.
-sudo ./calicoctl checksystem --fix
+sudo ./calicoctl checksystem
 
 # Start the calico node service.  We must specify the ETCD_AUTHORITY variable since 
 # sudo uses its own environment.

--- a/docs/getting-started/powerstrip/EnvironmentSetup.md
+++ b/docs/getting-started/powerstrip/EnvironmentSetup.md
@@ -32,7 +32,7 @@ for using the default Docker networking.
 
 The two Linux servers require a recent version of Linux with a few network 
 network related kernel modules to be loaded. The easiest way to ensure this and
-that the servers meet the requirements is to run `calicoctl checksystem --fix`
+that the servers meet the requirements is to run `calicoctl checksystem`
 
 The servers also need:
 - Docker to be running - since the Calico agent is packaged as a Docker 

--- a/docs/getting-started/powerstrip/cloud-config/user-data-first
+++ b/docs/getting-started/powerstrip/cloud-config/user-data-first
@@ -47,4 +47,3 @@ write_files:
     #!/usr/bin/bash -e
     wget -O /opt/bin/calicoctl https://github.com/projectcalico/calico-docker/releases/download/v0.4.9/calicoctl
     chmod +x /opt/bin/calicoctl
-    /opt/bin/calicoctl checksystem --fix

--- a/docs/getting-started/powerstrip/cloud-config/user-data-others
+++ b/docs/getting-started/powerstrip/cloud-config/user-data-others
@@ -42,4 +42,3 @@ write_files:
     #!/usr/bin/bash -e
     wget -O /opt/bin/calicoctl https://github.com/projectcalico/calico-docker/releases/download/v0.4.9/calicoctl
     chmod +x /opt/bin/calicoctl
-    /opt/bin/calicoctl checksystem --fix

--- a/docs/getting-started/powerstrip/vagrant-ubuntu/Vagrantfile
+++ b/docs/getting-started/powerstrip/vagrant-ubuntu/Vagrantfile
@@ -46,9 +46,6 @@ Vagrant.configure(2) do |config|
 
       host.vm.provision :shell, inline: "chmod +x /usr/local/bin/calicoctl"
 
-      # Ensure that the iptables kernel modules are loaded etc...
-      host.vm.provision :shell, inline: "sudo calicoctl checksystem --fix"
-
       # Calico uses etcd for clustering. Install it on the first host only.
       if i == 1
         host.vm.provision :docker do |d|


### PR DESCRIPTION
+ Fix #539
+ Remove all references to the --fix flag in guides
+ Remove checksystem calls in startup scripts
+ Make module checks more reliable