### PR TITLE
increment metric of default route when adding new default route

### DIFF
--- a/calico_containers/calico_ctl/container.py
+++ b/calico_containers/calico_ctl/container.py
@@ -282,6 +282,7 @@ def container_add(container_id, ip, interface):
 
     # Create the veth, move into the container namespace, add the IP and
     # set up the default routes.
+    netns.increment_metrics(namespace)
     netns.create_veth(ep.name, ep.temp_interface_name)
     netns.move_veth_into_ns(namespace, ep.temp_interface_name, interface)
     netns.add_ip_to_ns_veth(namespace, ip, interface)

--- a/calico_containers/tests/unit/container_test.py
+++ b/calico_containers/tests/unit/container_test.py
@@ -90,6 +90,7 @@ class TestContainer(unittest.TestCase):
         # Check an enpoint object was returned
         self.assertTrue(isinstance(test_return, Endpoint))
 
+        self.assertTrue(m_netns.increment_metrics.called)
         self.assertTrue(m_netns.create_veth.called)
         self.assertTrue(m_netns.move_veth_into_ns.called)
         self.assertTrue(m_netns.add_ip_to_ns_veth.called)
@@ -231,6 +232,7 @@ class TestContainer(unittest.TestCase):
         self.assertTrue(m_get_pool_or_exit.called)
         self.assertFalse(m_client.get_default_next_hops.called)
         self.assertFalse(m_client.release_ips.called)
+        self.assertFalse(m_netns.increment_metrics.called)
         self.assertFalse(m_netns.create_veth.called)
 
     @patch('calico_ctl.container.enforce_root', autospec=True)


### PR DESCRIPTION
Add call to new libcalico functionality merged in [#41 - increment metric of default routes to preserve networking before calico](https://github.com/projectcalico/libcalico/pull/41) 

This fixes #447 