### PR TITLE
Improve output for endpoint profile commands

### DIFF
--- a/calico_containers/calico_ctl/endpoint.py
+++ b/calico_containers/calico_ctl/endpoint.py
@@ -231,6 +231,8 @@ def endpoint_profile_append(hostname, orchestrator_id, workload_id,
     The profile list may not contain duplicate entries, invalid profile names,
     or profiles that are already in the containers list.
 
+    If no profile is specified, nothing happens.
+
     :param hostname: The host that the targeted endpoint resides on.
     :param orchestrator_id: The orchestrator that created the targeted endpoint.
     :param workload_id: The ID of workload which created the targeted endpoint.
@@ -241,26 +243,30 @@ def endpoint_profile_append(hostname, orchestrator_id, workload_id,
     """
     # Validate the profile list.
     validate_profile_list(profile_names)
-    try:
-        client.append_profiles_to_endpoint(profile_names,
-                                           hostname=hostname,
-                                           orchestrator_id=orchestrator_id,
-                                           workload_id=workload_id,
-                                           endpoint_id=endpoint_id)
-        print_paragraph("Profile(s) %s appended." %
-                        (", ".join(profile_names)))
-    except KeyError:
-        print "Failed to append profiles to endpoint.\n"
-        print_paragraph("Endpoint %s is unknown to Calico.\n" % endpoint_id)
-        sys.exit(1)
-    except ProfileAlreadyInEndpoint, e:
-        print_paragraph("Profile %s is already in endpoint "
-                        "profile list" % e.profile_name)
-    except MultipleEndpointsMatch:
-        print_paragraph("More than 1 endpoint matches the provided criteria.  "
-                        "Please provide additional parameters to refine the "
-                        "search.")
-        sys.exit(1)
+
+    if not profile_names:
+        print_paragraph("No profile specified.")
+    else:
+        try:
+            client.append_profiles_to_endpoint(profile_names,
+                                               hostname=hostname,
+                                               orchestrator_id=orchestrator_id,
+                                               workload_id=workload_id,
+                                               endpoint_id=endpoint_id)
+            print_paragraph("Profile(s) %s appended." %
+                            (", ".join(profile_names)))
+        except KeyError:
+            print "Failed to append profiles to endpoint.\n"
+            print_paragraph("Endpoint %s is unknown to Calico.\n" % endpoint_id)
+            sys.exit(1)
+        except ProfileAlreadyInEndpoint, e:
+            print_paragraph("Profile %s is already in endpoint "
+                            "profile list" % e.profile_name)
+        except MultipleEndpointsMatch:
+            print_paragraph("More than 1 endpoint matches the provided criteria.  "
+                            "Please provide additional parameters to refine the "
+                            "search.")
+            sys.exit(1)
 
 
 def endpoint_profile_set(hostname, orchestrator_id, workload_id,
@@ -274,6 +280,8 @@ def endpoint_profile_set(hostname, orchestrator_id, workload_id,
     query must be specific enough to match a single endpoint or it will fail.
 
     The profile list may not contain duplicate entries or invalid profile names.
+
+    If no profile is specified, the profile list is set to be empty.
 
     :param hostname: The host that the targeted endpoint resides on.
     :param orchestrator_id: The orchestrator that created the targeted endpoint.
@@ -293,8 +301,11 @@ def endpoint_profile_set(hostname, orchestrator_id, workload_id,
                                         orchestrator_id=orchestrator_id,
                                         workload_id=workload_id,
                                         endpoint_id=endpoint_id)
-        print_paragraph("Profile(s) %s set." %
-                        (", ".join(profile_names)))
+        if not profile_names:
+           print_paragraph("Removed all profiles from endpoint.")
+        else:
+            print_paragraph("Profile(s) set to %s." %
+                            (", ".join(profile_names)))
     except KeyError:
         print "Failed to set profiles for endpoint.\n"
         print_paragraph("Endpoint could not be found.\n")
@@ -314,6 +325,8 @@ def endpoint_profile_remove(hostname, orchestrator_id, workload_id,
     The profile list may not contain duplicate entries, invalid profile names,
     or profiles that are not already in the containers list.
 
+    If no profile is specified, nothing happens.
+
     :param hostname: The host that the targeted endpoint resides on.
     :param orchestrator_id: The orchestrator that created the targeted endpoint.
     :param workload_id: The ID of workload which created the targeted endpoint.
@@ -325,25 +338,28 @@ def endpoint_profile_remove(hostname, orchestrator_id, workload_id,
     # Validate the profile list.
     validate_profile_list(profile_names)
 
-    try:
-        client.remove_profiles_from_endpoint(profile_names,
-                                             hostname=hostname,
-                                             orchestrator_id=orchestrator_id,
-                                             workload_id=workload_id,
-                                             endpoint_id=endpoint_id)
-        print_paragraph("Profile(s) %s removed." %
-                        (",".join(profile_names)))
-    except KeyError:
-        print "Failed to remove profiles from endpoint.\n"
-        print_paragraph("Endpoint could not be found.\n")
-        sys.exit(1)
-    except ProfileNotInEndpoint, e:
-        print_paragraph("Profile %s is not in endpoint profile "
-                        "list." % e.profile_name)
-    except MultipleEndpointsMatch:
-        print "More than 1 endpoint matches the provided criteria. " \
-              "Please provide additional parameters to refine the search."
-        sys.exit(1)
+    if not profile_names:
+        print_paragraph("No profile specified.")
+    else:
+        try:
+            client.remove_profiles_from_endpoint(profile_names,
+                                                 hostname=hostname,
+                                                 orchestrator_id=orchestrator_id,
+                                                 workload_id=workload_id,
+                                                 endpoint_id=endpoint_id)
+            print_paragraph("Profile(s) %s removed." %
+                            (",".join(profile_names)))
+        except KeyError:
+            print "Failed to remove profiles from endpoint.\n"
+            print_paragraph("Endpoint could not be found.\n")
+            sys.exit(1)
+        except ProfileNotInEndpoint, e:
+            print_paragraph("Profile %s is not in endpoint profile "
+                            "list." % e.profile_name)
+        except MultipleEndpointsMatch:
+            print "More than 1 endpoint matches the provided criteria. " \
+                  "Please provide additional parameters to refine the search."
+            sys.exit(1)
 
 
 def endpoint_profile_show(hostname, orchestrator_id, workload_id, endpoint_id):

--- a/calico_containers/tests/unit/endpoint_test.py
+++ b/calico_containers/tests/unit/endpoint_test.py
@@ -15,7 +15,7 @@
 import unittest
 
 from mock import patch
-from nose_parameterized import parameterized
+from nose_parameterized import parameterized, param
 from calico_ctl import endpoint
 
 
@@ -37,3 +37,89 @@ class TestEndpoint(unittest.TestCase):
             # Assert method exits if bad input
             self.assertEqual(m_sys_exit.called, sys_exit_called)
 
+    @parameterized.expand([param(['profile-1', 'profile-2', 'profile-3']),
+                           param(['Profile1', 'Profile!']),
+                           param([])
+    ])
+    def test_endpoint_profile_set(self, profiles):
+        """
+        Test setting profiles on an endpoint calls correct functions
+        """
+        with patch("calico_ctl.endpoint.client", autospec=True) as m_client:
+            hostname = "m_hostname"
+            orchestrator_id = "m_orchestrator_id"
+            workload_id = "m_workload_id"
+            endpoint_id = "m_endpoint_id"
+
+            endpoint.endpoint_profile_set(hostname,
+                                          orchestrator_id,
+                                          workload_id,
+                                          endpoint_id,
+                                          profiles)
+
+            m_client.set_profiles_on_endpoint.assert_called_once_with(
+                                               profiles,
+                                               hostname=hostname,
+                                               orchestrator_id=orchestrator_id,
+                                               workload_id=workload_id,
+                                               endpoint_id=endpoint_id)
+
+    @parameterized.expand([
+        (['profile-1', 'profile-2', 'profile-3'], True),
+        (['test_prof'], True),
+        ([], False)
+    ])
+    def test_endpoint_profile_append(self, profiles, m_append_profiles_called):
+        """
+        Test appending profiles on an endpoint calls correct functions
+        """
+        with patch("calico_ctl.endpoint.client", autospec=True) as m_client:
+            hostname = "m_hostname"
+            orchestrator_id = "m_orchestrator_id"
+            workload_id = "m_workload_id"
+            endpoint_id = "m_endpoint_id"
+            endpoint.endpoint_profile_append(hostname,
+                                             orchestrator_id,
+                                             workload_id,
+                                             endpoint_id,
+                                             profiles)
+
+            self.assertEqual(m_client.append_profiles_to_endpoint.called,
+                             m_append_profiles_called)
+            if m_append_profiles_called:
+                m_client.append_profiles_to_endpoint.assert_called_once_with(
+                                               profiles,
+                                               hostname=hostname,
+                                               orchestrator_id=orchestrator_id,
+                                               workload_id=workload_id,
+                                               endpoint_id=endpoint_id)
+
+    @parameterized.expand([
+        (['profile-1', 'profile-2', 'profile-3'], True),
+        (['test_prof'], True),
+        ([], False)
+    ])
+    def test_endpoint_profile_remove(self, profiles, m_remove_profiles_called):
+        """
+        Test removing profiles from an endpoint calls correct functions.
+        """
+        with patch("calico_ctl.endpoint.client", autospec=True) as m_client:
+            hostname = "m_hostname"
+            orchestrator_id = "m_orchestrator_id"
+            workload_id = "m_workload_id"
+            endpoint_id = "m_endpoint_id"
+            endpoint.endpoint_profile_remove(hostname,
+                                             orchestrator_id,
+                                             workload_id,
+                                             endpoint_id,
+                                             profiles)
+
+            self.assertEqual(m_client.remove_profiles_from_endpoint.called,
+                             m_remove_profiles_called)
+            if m_remove_profiles_called:
+                m_client.remove_profiles_from_endpoint.assert_called_once_with(
+                                               profiles,
+                                               hostname=hostname,
+                                               orchestrator_id=orchestrator_id,
+                                               workload_id=workload_id,
+                                               endpoint_id=endpoint_id)


### PR DESCRIPTION
When no profile is specified, output of the commands is unclear.  Add specific output for these cases to make it clear what action is being taken.