### PR TITLE
Fix version of felix. Master version now has fix we need

### DIFF
--- a/calico_node/build.sh
+++ b/calico_node/build.sh
@@ -22,7 +22,7 @@ curl -L https://github.com/projectcalico/calico-bird/releases/download/v0.1.0/bi
 chmod +x /sbin/*
 
 # Install Felix
-pip install git+https://github.com/projectcalico/calico.git@iptables-protocol-number
+pip install git+https://github.com/projectcalico/calico.git
 
 # Output the python library list
 pip list > libraries.txt


### PR DESCRIPTION
Reverts [60717cc3](https://github.com/projectcalico/calico-docker/commit/60717cc36a56392968cf1f8b92af102f6cbc36d4) since [#866](https://github.com/projectcalico/calico/pull/866) has been merged to master.

The `iptables-protocol-number` branch was deleted, so builds are broken until this PR is accepted!