### PR TITLE
Add a simple IPv6 mainline test

### DIFF
--- a/calico_containers/tests/st/no_orchestrator/test_add_autoassigned_ip.py
+++ b/calico_containers/tests/st/no_orchestrator/test_add_autoassigned_ip.py
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import unittest
 
-from tests.st.test_base import TestBase
+from tests.st.test_base import TestBase, HOST_IPV6
 from tests.st.utils.docker_host import DockerHost
 
 """
@@ -64,6 +65,7 @@ class TestAutoAssignIp(TestBase):
             workloads[0].assert_can_ping("192.168.0.1", retries=3)
             workloads[1].assert_can_ping("192.168.0.0", retries=3)
 
+    @unittest.skipUnless(HOST_IPV6, "Host does not have an IPv6 address")
     def test_add_autoassigned_ipv6(self):
         """
         Test "calicoctl container add <container> ipv6"
@@ -99,6 +101,7 @@ class TestAutoAssignIp(TestBase):
             workloads[0].assert_can_ping("192.168.0.1", retries=3)
             workloads[1].assert_can_ping("192.168.0.0", retries=3)
 
+    @unittest.skipUnless(HOST_IPV6, "Host does not have an IPv6 address")
     def test_add_autoassigned_pool_ipv6(self):
         """
         Test "calicoctl container add <container> <IPv6 CIDR>"

--- a/calico_containers/tests/st/no_orchestrator/test_add_autoassigned_ip.py
+++ b/calico_containers/tests/st/no_orchestrator/test_add_autoassigned_ip.py
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from subprocess import CalledProcessError
-from unittest import skip
 
 from tests.st.test_base import TestBase
 from tests.st.utils.docker_host import DockerHost
@@ -48,7 +46,7 @@ class TestAutoAssignIp(TestBase):
         """
         Test "calicoctl container add <container> ipv4"
         """
-        with DockerHost('host') as host:
+        with DockerHost('host', dind=False) as host:
             # Test that auto-assiging IPv4 addresses gives what we expect
             workloads = self._setup_env(host, count=2, ip="ipv4")
 
@@ -66,12 +64,11 @@ class TestAutoAssignIp(TestBase):
             workloads[0].assert_can_ping("192.168.0.1", retries=3)
             workloads[1].assert_can_ping("192.168.0.0", retries=3)
 
-    @skip("IPv6 st tests aren't working yet")
     def test_add_autoassigned_ipv6(self):
         """
         Test "calicoctl container add <container> ipv6"
         """
-        with DockerHost('host') as host:
+        with DockerHost('host', dind=False) as host:
             # Test that auto-assiging IPv4 addresses gives what we expect
             workloads = self._setup_env(host, count=2, ip="ipv6")
 
@@ -94,7 +91,7 @@ class TestAutoAssignIp(TestBase):
         Test "calicoctl container add <container> <IPv4 CIDR>"
         (192.168.0.0/16)
         """
-        with DockerHost('host') as host:
+        with DockerHost('host', dind=False) as host:
             # Test that auto-assiging IPv4 addresses gives what we expect
             workloads = self._setup_env(host, count=2,
                                         ip=self.DEFAULT_IPV4_POOL)
@@ -102,13 +99,12 @@ class TestAutoAssignIp(TestBase):
             workloads[0].assert_can_ping("192.168.0.1", retries=3)
             workloads[1].assert_can_ping("192.168.0.0", retries=3)
 
-    @skip("IPv6 st tests aren't working yet")
     def test_add_autoassigned_pool_ipv6(self):
         """
         Test "calicoctl container add <container> <IPv6 CIDR>"
         (fd80:24e2:f998:72d6::/64)
         """
-        with DockerHost('host') as host:
+        with DockerHost('host', dind=False) as host:
             # Test that auto-assiging IPv6 addresses gives what we expect
             workloads = self._setup_env(host, count=2,
                                         ip=self.DEFAULT_IPV6_POOL)

--- a/calico_containers/tests/st/no_orchestrator/test_mainline_single_host.py
+++ b/calico_containers/tests/st/no_orchestrator/test_mainline_single_host.py
@@ -11,11 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import unittest
 
-from tests.st.test_base import TestBase
+from tests.st.test_base import TestBase, HOST_IPV6
 from tests.st.utils.docker_host import DockerHost
-from tests.st.utils.workload import NET_NONE
-
 
 class TestNoOrchestratorSingleHost(TestBase):
     def test_single_host_ipv4(self):
@@ -52,6 +51,7 @@ class TestNoOrchestratorSingleHost(TestBase):
             host.calicoctl("node stop")
             host.calicoctl("node remove")
 
+    @unittest.skipUnless(HOST_IPV6, "Host does not have an IPv6 address")
     def test_single_host_ipv6(self):
         """
         Test mainline functionality without using an orchestrator plugin

--- a/calico_containers/tests/st/test_base.py
+++ b/calico_containers/tests/st/test_base.py
@@ -17,6 +17,8 @@ from unittest import TestCase
 from tests.st.utils.utils import get_ip
 import logging
 
+HOST_IPV6 = get_ip(v6=True)
+
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 logger = logging.getLogger(__name__)
 

--- a/calico_containers/tests/st/utils/docker_host.py
+++ b/calico_containers/tests/st/utils/docker_host.py
@@ -57,7 +57,8 @@ class DockerHost(object):
             for command in post_docker_commands:
                 self.execute(command)
         else:
-            self.ip = get_ip()
+            self.ip = get_ip(False)
+            self.ip6 = get_ip(True)
 
         if start_calico:
             self.start_calico_node()

--- a/calico_containers/tests/st/utils/docker_host.py
+++ b/calico_containers/tests/st/utils/docker_host.py
@@ -57,8 +57,8 @@ class DockerHost(object):
             for command in post_docker_commands:
                 self.execute(command)
         else:
-            self.ip = get_ip(False)
-            self.ip6 = get_ip(True)
+            self.ip = get_ip(v6=False)
+            self.ip6 = get_ip(v6=True)
 
         if start_calico:
             self.start_calico_node()

--- a/calico_containers/tests/st/utils/utils.py
+++ b/calico_containers/tests/st/utils/utils.py
@@ -51,6 +51,7 @@ def get_ip(v6=False):
             ips = get_host_ips(version)
             if ips:
                 ip = ips[0]
+
     return ip
 
 

--- a/calico_containers/tests/st/utils/utils.py
+++ b/calico_containers/tests/st/utils/utils.py
@@ -20,26 +20,37 @@ from subprocess import CalledProcessError
 from exceptions import CommandExecError
 import re
 import json
+from pycalico.util import get_host_ips
 
 LOCAL_IP_ENV = "MY_IP"
+LOCAL_IPv6_ENV = "MY_IPv6"
 logger = logging.getLogger(__name__)
 
 
-def get_ip():
+def get_ip(v6=False):
     """
     Return a string of the IP of the hosts interface.
     Try to get the local IP from the environment variables.  This allows
     testers to specify the IP address in cases where there is more than one
     configured IP address for the test system.
     """
-    try:
-        ip = os.environ[LOCAL_IP_ENV]
-    except KeyError:
-        # No env variable set; try to auto detect.
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.connect(("8.8.8.8", 80))
-        ip = s.getsockname()[0]
-        s.close()
+    env = LOCAL_IPv6_ENV if v6 else LOCAL_IP_ENV
+    ip = os.environ.get(env)
+    if not ip:
+        try:
+            # No env variable set; try to auto detect.
+            socket_type = socket.AF_INET6 if v6 else socket.AF_INET
+            s = socket.socket(socket_type, socket.SOCK_DGRAM)
+            remote_ip = "2001:4860:4860::8888" if v6 else "8.8.8.8"
+            s.connect((remote_ip, 0))
+            ip = s.getsockname()[0]
+            s.close()
+        except Exception:
+            # Failed to connect, just try to get the address from the interfaces
+            version = 6 if v6 else 4
+            ips = get_host_ips(version)
+            if ips:
+                ip = ips[0]
     return ip
 
 

--- a/calico_containers/tests/st/utils/workload.py
+++ b/calico_containers/tests/st/utils/workload.py
@@ -60,12 +60,6 @@ class Workload(object):
                                                        image)
         host.execute(command)
 
-        version_key = "IPAddress"
-        # TODO Use version_key = "GlobalIPv6Address" for IPv6
-        ip_command = "docker inspect --format '{{ .NetworkSettings.Networks.%s.%s }}' %s" % \
-                                                            (network, version_key, name)
-        self.ip = host.execute(ip_command)
-
     def execute(self, command):
         """
         Execute arbitrary commands on this workload.

--- a/calico_node/build.sh
+++ b/calico_node/build.sh
@@ -7,7 +7,7 @@ set -x
 echo "http://alpine.gliderlabs.com/alpine/edge/testing" >> /etc/apk/repositories
 
 # These packages make it into the final image.
-apk -U add runit python py-setuptools libffi ip6tables ipset iputils
+apk -U add runit python py-setuptools libffi ip6tables ipset iputils iproute2
 
 # These packages are only used for building and get removed.
 apk add --virtual temp python-dev libffi-dev py-pip alpine-sdk curl


### PR DESCRIPTION
It doesn't work Docker-in-Docker - that requires Docker to do some IPv6 which requires additional config.

This works as long as an interface on the host has an autoconfigured link local address.