### PR TITLE
Run STs in a container

### DIFF
--- a/build_calicoctl/requirements.txt
+++ b/build_calicoctl/requirements.txt
@@ -1,15 +1,8 @@
-coverage==3.7.1
 docopt==0.6.2
-mock==1.0.1
 PyInstaller==2.1
 six==1.9.0
-nose==1.3.1
-nose-timer
-nose-parameterized
 docker-py==1.2.1
 sh==1.11
-coveralls
 prettytable==0.7.2
 netaddr==0.7.15
-subprocess32
 git+https://github.com/projectcalico/libcalico.git

--- a/calico_containers/tests/st/utils/docker_host.py
+++ b/calico_containers/tests/st/utils/docker_host.py
@@ -21,6 +21,7 @@ from workload import Workload
 from network import DockerNetwork
 
 logger = logging.getLogger(__name__)
+CHECKOUT_DIR = os.getenv("HOST_CHECKOUT_DIR", os.getcwd())
 
 class DockerHost(object):
     """
@@ -29,8 +30,8 @@ class DockerHost(object):
     """
     def __init__(self, name, start_calico=True, dind=True,
                  additional_docker_options="",
-                 post_docker_commands=["docker load --input /code/calico_containers/calico-node.tar",
-                                       "docker load --input /code/calico_containers/busybox.tar"]):
+                 post_docker_commands=["docker load -i /code/calico_containers/calico-node.tar",
+                                       "docker load -i /code/calico_containers/busybox.tar"]):
         self.name = name
         self.dind = dind
         self.workloads = set()
@@ -45,7 +46,7 @@ class DockerHost(object):
                         "-v %s/docker:/usr/local/bin/docker "
                         "-v %s:/code --name %s "
                         "calico/dind:latest docker daemon --storage-driver=aufs %s" %
-                    (os.getcwd(), os.getcwd(), self.name, additional_docker_options))
+                    (CHECKOUT_DIR, CHECKOUT_DIR, self.name, additional_docker_options))
 
             self.ip = log_and_run("docker inspect --format "
                               "'{{.NetworkSettings.Networks.bridge.IPAddress}}' %s" % self.name)

--- a/calico_containers/tests/st/utils/utils.py
+++ b/calico_containers/tests/st/utils/utils.py
@@ -45,7 +45,7 @@ def get_ip(v6=False):
             s.connect((remote_ip, 0))
             ip = s.getsockname()[0]
             s.close()
-        except Exception:
+        except BaseException:
             # Failed to connect, just try to get the address from the interfaces
             version = 6 if v6 else 4
             ips = get_host_ips(version)

--- a/calico_containers/tests/st/utils/workload.py
+++ b/calico_containers/tests/st/utils/workload.py
@@ -31,7 +31,7 @@ class Workload(object):
     These are the end-users containers that will run application-level
     software.
     """
-    def __init__(self, host, name, image="busybox", network=None):
+    def __init__(self, host, name, image="busybox", network="bridge"):
         """
         Create the workload and detect its IPs.
 
@@ -48,17 +48,13 @@ class Workload(object):
         """
         self.host = host
         self.name = name
-
-        network_command = ""
-        if network:
-            if network is not NET_NONE:
-                assert isinstance(network, DockerNetwork)
-            network_command = "--net %s" % network
-
-        command = "docker run -tid --name %s %s %s" % (name,
-                                                       network_command,
-                                                       image)
+        command = "docker run -tid --name %s --net %s %s" % (name,
+                                                             network,
+                                                             image)
         host.execute(command)
+        self.ip = host.execute("docker inspect --format "
+                              "'{{.NetworkSettings.Networks.%s.IPAddress}}' %s"
+                               % (network, name))
 
     def execute(self, command):
         """

--- a/calico_node/build.sh
+++ b/calico_node/build.sh
@@ -3,7 +3,6 @@ set -e
 set -x
 
 # Ensure the main and testing repros are present. Needed for runit
-#echo "http://dl-3.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
 echo "http://alpine.gliderlabs.com/alpine/edge/testing" >> /etc/apk/repositories
 
 # These packages make it into the final image.

--- a/calico_test/Dockerfile
+++ b/calico_test/Dockerfile
@@ -1,0 +1,32 @@
+# Copyright 2015 Metaswitch Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM jeanblanchard/alpine-glibc
+MAINTAINER Tom Denham <tom@projectcalico.org>
+
+RUN apk --update add python py-setuptools iproute2 iputils ip6tables ipset
+
+# Could make this container smaller by merging the next three lines with a remove.
+RUN apk add git py-pip musl-dev gcc python-dev
+ADD calico_test/requirements.txt /
+RUN pip install -r requirements.txt
+
+# The test _framework_ needs to be part of the image - everything else gets volume mounted
+ADD calico_containers/tests/st/utils /tests/st/utils
+ADD calico_containers/tests/st/test_base.py /tests/st/test_base.py
+RUN touch /tests/__init__.py /tests/st/__init__.py
+RUN ln -s /code/docker /usr/local/bin/docker
+WORKDIR /code/
+
+
+

--- a/calico_test/requirements.txt
+++ b/calico_test/requirements.txt
@@ -1,0 +1,11 @@
+coverage
+coveralls
+mock==1.0.1
+sh
+nose
+nose-timer
+nose-parameterized
+docker-py
+netaddr
+prettytable
+git+https://github.com/projectcalico/libcalico.git


### PR DESCRIPTION
Create a container for running the STs.
- This container can be used as a way of sharing the ST framework code to libnetwork-plugin
- It reduces the requirements for running the STs - just `make st` on any host with a docker daemon.
