### PR TITLE
Use debian:jessie to build calicoctl for python 2.7.9

### DIFF
--- a/calicoctl/Dockerfile
+++ b/calicoctl/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM debian:wheezy
+FROM debian:jessie
 MAINTAINER Tom Denham <tom@projectcalico.org>
 
 WORKDIR /code/


### PR DESCRIPTION
Switch from using `debian:wheezy` to `debian:jessie` when building the calicoctl binary. This fixes a potential security issue when running etcd with SSL using urlib3 with Python 2.7.3. See [this page](https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning) from urllib3 for more details.

`wheezy` uses Python 2.7.3, whereas `jessie` uses 2.7.9.